### PR TITLE
refactor(dags): silver_to_neo4j_csv를 별도 DAG로 분리

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,13 +193,21 @@ docker run --network host oliveyoung-pipeline silver_to_neo4j_csv
 
 ## Airflow 연동
 
-`dags/oliveyoung_pipeline.py`에 DockerOperator 기반 DAG가 정의되어 있습니다.
+DockerOperator 기반 DAG가 두 개로 분리되어 있습니다.
+
+- `dags/oliveyoung_pipeline.py` — 메인 ETL 파이프라인
+- `dags/oliveyoung_silver_to_neo4j_csv.py` — Neo4j CSV 익스포트 (초기 적재용, 독립 DAG)
 
 ```
-sync_reference_data  →  bronze_to_silver  →  silver_to_gold  →  silver_to_neo4j_csv
+oliveyoung_pipeline:
+  sync_reference_data  →  bronze_to_silver  →  silver_to_gold
+
+oliveyoung_silver_to_neo4j_csv:
+  silver_to_neo4j_csv   (초기 적재용 — 필요 시 수동 트리거)
 ```
 
-- `schedule=None` — 크롤링 DAG 완료 후 `TriggerDagRunOperator`로 트리거됩니다.
+- `oliveyoung_pipeline`은 `schedule=None` — 크롤링 DAG 완료 후 `TriggerDagRunOperator`로 트리거됩니다.
+- `oliveyoung_silver_to_neo4j_csv`는 초기 1회 적재 용도로, 트리거 없이 수동으로 실행합니다.
 
 ```python
 from airflow.operators.trigger_dagrun import TriggerDagRunOperator

--- a/dags/oliveyoung_silver_to_neo4j_csv.py
+++ b/dags/oliveyoung_silver_to_neo4j_csv.py
@@ -22,32 +22,16 @@ COMMON = dict(
 )
 
 with DAG(
-    dag_id="oliveyoung_pipeline",
-    schedule=None,  # 크롤링 DAG의 TriggerDagRunOperator로 실행
+    dag_id="oliveyoung_silver_to_neo4j_csv",
+    schedule=None,  # 초기 적재용 — 필요 시 수동 트리거
     start_date=datetime(2026, 1, 1),
     catchup=False,
-    tags=["oliveyoung", "etl"],
+    tags=["oliveyoung", "etl", "neo4j"],
 ) as dag:
 
-    sync_reference = DockerOperator(
-        task_id="sync_reference_data",
+    silver_to_neo4j_csv = DockerOperator(
+        task_id="silver_to_neo4j_csv",
         image=IMAGE,
-        command="sync_reference",
+        command="silver_to_neo4j_csv",
         **COMMON,
     )
-
-    bronze_to_silver = DockerOperator(
-        task_id="bronze_to_silver",
-        image=IMAGE,
-        command="bronze_to_silver",
-        **COMMON,
-    )
-
-    silver_to_gold = DockerOperator(
-        task_id="silver_to_gold",
-        image=IMAGE,
-        command="silver_to_gold",
-        **COMMON,
-    )
-
-    sync_reference >> bronze_to_silver >> silver_to_gold


### PR DESCRIPTION
## 변경 사항

마지막 task인 `silver_to_neo4j_csv`를 메인 파이프라인에서 분리하여 별도 DAG로 구성했습니다.

- **`dags/oliveyoung_pipeline.py`** — `silver_to_neo4j_csv` task 제거. 체인이 `sync_reference_data → bronze_to_silver → silver_to_gold`로 종료됩니다.
- **`dags/oliveyoung_silver_to_neo4j_csv.py`** (신규) — `silver_to_neo4j_csv` task를 담은 독립 DAG (`dag_id=oliveyoung_silver_to_neo4j_csv`).
- **`README.md`** — Airflow 연동 섹션을 두 DAG 구조로 갱신.

## 배경

`silver_to_neo4j_csv`는 초기 1회 적재 용도이므로, 매 파이프라인 실행마다 돌 필요가 없습니다. 따라서 트리거 없이 `schedule=None`으로 두고 필요 시 수동 실행하는 독립 DAG로 분리했습니다.