### PR TITLE
feat(cdc): change_log 스키마에 rating, review_count, review_stats 추가

### DIFF
--- a/gold_pipeline/schemas.py
+++ b/gold_pipeline/schemas.py
@@ -9,9 +9,11 @@ from pyiceberg.schema import Schema
 from pyiceberg.types import (
     NestedField,
     StringType,
+    FloatType,
     IntegerType,
     LongType,
     ListType,
+    MapType,
     TimestamptzType,
 )
 from pyiceberg.partitioning import PartitionSpec, PartitionField
@@ -54,20 +56,35 @@ GOLD_INGREDIENT_FREQUENCY_SORT = SortOrder(
 # change_type 값:
 #   NEW     — 현재 배치에 새로 등장한 product
 #   REMOVED — 이전 배치에 있었으나 현재 배치에서 사라진 product
+#   CHANGED — product_ingredients / rating / review_count / review_stats 변경
+
+# map<string, map<string, string>> — silver 와 동일 구조, field_id 충돌 방지를 위해 200번대 사용
+_CHANGE_LOG_REVIEW_STATS_TYPE = MapType(
+    key_id=201, key_type=StringType(),
+    value_id=202, value_type=MapType(
+        key_id=203, key_type=StringType(),
+        value_id=204, value_type=StringType(),
+        value_required=False,
+    ),
+    value_required=False,
+)
 
 GOLD_PRODUCT_CHANGE_LOG_SCHEMA = Schema(
-    NestedField(1, "batch_date",  TimestamptzType(), required=False),  # 파티션 키
-    NestedField(2, "product_id",  StringType(),      required=True),
-    NestedField(3, "category_id", StringType(),      required=False),
-    NestedField(4, "change_type", StringType(),      required=False),  # NEW | REMOVED
-    NestedField(5, "product_name",    StringType(),  required=False),
-    NestedField(6, "product_brand",   StringType(),  required=False),
+    NestedField(1,  "batch_date",  TimestamptzType(), required=False),  # 파티션 키
+    NestedField(2,  "product_id",  StringType(),      required=True),
+    NestedField(3,  "category_id", StringType(),      required=False),
+    NestedField(4,  "change_type", StringType(),      required=False),  # NEW | REMOVED | CHANGED
+    NestedField(5,  "product_name",    StringType(),  required=False),
+    NestedField(6,  "product_brand",   StringType(),  required=False),
     NestedField(
         7, "product_ingredients",
         ListType(element_id=100, element_type=StringType(), element_required=False),
         required=False,
     ),
-    NestedField(8, "batch_job",   StringType(),      required=False),
+    NestedField(8,  "rating",        FloatType(),                  required=False),
+    NestedField(9,  "review_count",  IntegerType(),                required=False),
+    NestedField(10, "review_stats",  _CHANGE_LOG_REVIEW_STATS_TYPE, required=False),
+    NestedField(11, "batch_job",     StringType(),                 required=False),
 )
 
 # batch_date 일 단위 파티션

--- a/gold_pipeline/write_gold.py
+++ b/gold_pipeline/write_gold.py
@@ -47,6 +47,18 @@ def _build_arrow(df: pd.DataFrame, table) -> pa.Table:
             lambda v: [str(x) for x in v] if isinstance(v, list) else None
         )
 
+    # map<string, map<string, string>> 정규화
+    if "review_stats" in work_df.columns:
+        def _normalize_review_stats(v):
+            if not isinstance(v, dict):
+                return None
+            return {
+                str(k): {str(ik): str(iv) for ik, iv in inner.items()}
+                if isinstance(inner, dict) else {}
+                for k, inner in v.items()
+            }
+        work_df["review_stats"] = work_df["review_stats"].apply(_normalize_review_stats)
+
     arrow_dict: dict[str, pa.Array] = {}
     for field in iceberg_arrow_schema:
         col = field.name
@@ -153,7 +165,8 @@ def write_gold_change_log(catalog, change_df: pd.DataFrame) -> None:
 
     new_cnt     = (change_df["change_type"] == "NEW").sum()
     removed_cnt = (change_df["change_type"] == "REMOVED").sum()
+    changed_cnt = (change_df["change_type"] == "CHANGED").sum()
     logger.info(
         f"gold_product_change_log append 완료: "
-        f"NEW={new_cnt}건  REMOVED={removed_cnt}건"
+        f"NEW={new_cnt}건  REMOVED={removed_cnt}건  CHANGED={changed_cnt}건"
     )


### PR DESCRIPTION
## Summary

gold_product_change_log 스키마를 CDC CHANGED 감지 필드에 맞게 확장

- `schemas.py` — `GOLD_PRODUCT_CHANGE_LOG_SCHEMA`에 `rating`, `review_count`, `review_stats` 필드 추가 및 `change_type` 주석에 CHANGED 명시
- `write_gold.py` — `review_stats` map 타입 정규화(`map<str, map<str,str>>`) 및 CHANGED 카운트 로그 추가

## Test plan

- [ ] rating / review_count / review_stats 변경 시 change_log에 CHANGED 레코드 기록 확인
- [ ] review_stats가 None인 경우 정규화 후 null로 저장 확인
- [ ] 기존 NEW / REMOVED 레코드 write 회귀 없음 확인
- [ ] 기존 gold_product_change_log 테이블이 있는 경우 schema evolution 적용 필요