### PR TITLE
feat(silver_to_gold): log_dq — 정합성 메트릭 (매핑률) 기록

### DIFF
--- a/gold_pipeline/write_gold_product_ingredients.py
+++ b/gold_pipeline/write_gold_product_ingredients.py
@@ -21,6 +21,7 @@ from pyiceberg.expressions import AlwaysTrue
 
 from config.settings import OliveyoungIceberg, INCIIceberg
 from gold_pipeline.write_gold import _build_arrow
+from oliveyoung_common.logging import log_dq
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +88,17 @@ def write_gold_product_ingredients(
     matched    = result_df["inci_name"].notna().sum()
     match_rate = matched / total if total else 0
     logger.info(f"unique 성분: {total}건 | INCI 매핑 성공: {matched}건 ({match_rate:.1%})")
+
+    # 정합성 메트릭 — Loki에서 LogQL로 추출 (매핑률 등)
+    log_dq(
+        logger,
+        stage="silver_to_gold",
+        batch_job=batch_job,
+        ingredients_unique=int(total),
+        ingredients_matched=int(matched),
+        ingredients_unmatched=int(total - matched),
+        match_rate=round(float(match_rate), 4),
+    )
 
     result_df["batch_job"]  = batch_job
     result_df["batch_date"] = pd.to_datetime(batch_date, utc=True)


### PR DESCRIPTION
## 무엇
`silver_to_gold` 단계(`write_gold_product_ingredients`)에서 INCI 매핑률 등 **정합성 수치**를 `[DQ]` 이벤트 한 줄로 기록.

## 어떻게
match_rate 계산 직후 `log_dq()` 호출 (oliveyoung_common 헬퍼):
```python
log_dq(logger, stage="silver_to_gold", batch_job=batch_job,
       ingredients_unique=..., ingredients_matched=...,
       ingredients_unmatched=..., match_rate=...)
```
`LOG_FORMAT=json`이라 Loki에 JSON 필드로 들어가고, Grafana에서 `| json | unwrap match_rate`로 패널화.

## 영향
- 순수 추가(기존 로깅/로직 무변경). import 1줄 + 호출 1블록.
- 서브모듈 핀은 이미 `f108f08`(log_dq 포함)이라 ImportError 없음.
- 머지 → 이미지 재빌드 → 다음 silver_to_gold 실행부터 DQ 로그 발생.

## 다음
Grafana에 silver→gold 매핑률 시계열 패널 추가 (별도 작업).

🤖 Generated with [Claude Code](https://claude.com/claude-code)