### PR TITLE
feat: bronze_to_silver 정합성 메트릭(log_dq) + gold_cdc 태스크

### DIFF
--- a/dags/oliveyoung_pipeline.py
+++ b/dags/oliveyoung_pipeline.py
@@ -50,6 +50,13 @@ with DAG(
         **COMMON,
     )
 
+    gold_cdc = DockerOperator(
+        task_id="gold_cdc",
+        image=IMAGE,
+        command="gold_pipeline",
+        **COMMON,
+    )
+
     neo4j_incremental = DockerOperator(
         task_id="neo4j_incremental",
         image=IMAGE,
@@ -63,4 +70,4 @@ with DAG(
         }},
     )
 
-    sync_reference >> bronze_to_silver >> silver_to_gold >> neo4j_incremental
+    sync_reference >> bronze_to_silver >> silver_to_gold >> gold_cdc >> neo4j_incremental

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -14,6 +14,9 @@ case "$1" in
   silver_to_gold)
     python src/silver_to_gold/main.py
     ;;
+  gold_pipeline)
+    python src/gold_pipeline_main.py
+    ;;
   silver_to_neo4j_csv)
     python src/silver_to_neo4j_csv/main.py
     ;;
@@ -24,7 +27,7 @@ case "$1" in
     python neo4j_incremental.py
     ;;
   *)
-    echo "Usage: $0 {create_reference_tables|sync_reference|bronze_to_silver|silver_to_gold|silver_to_neo4j_csv|create_gold_product_ingredients|neo4j_incremental}"
+    echo "Usage: $0 {create_reference_tables|sync_reference|bronze_to_silver|silver_to_gold|gold_pipeline|silver_to_neo4j_csv|create_gold_product_ingredients|neo4j_incremental}"
     exit 1
     ;;
 esac

--- a/src/bronze_to_silver/pipeline.py
+++ b/src/bronze_to_silver/pipeline.py
@@ -2,6 +2,7 @@
 Bronze → Silver 전처리 파이프라인 오케스트레이션 로직
 """
 
+import logging
 import sys
 
 from config.settings import OliveyoungIceberg, INCIIceberg, DuckDB
@@ -17,6 +18,9 @@ from src.bronze_to_silver.ac_builder import (
 )
 from src.bronze_to_silver.cleaner import process_pipeline
 from silver_pipeline.write_silver import write_to_iceberg, write_csv_to_s3
+from oliveyoung_common.logging import log_dq
+
+logger = logging.getLogger(__name__)
 
 
 def load_bronze_data(con):
@@ -103,6 +107,15 @@ def run_pipeline():
         product_name_norm_list = dicts.product_name_norm_list,
     )
     print(f"   정상: {len(silver_df)}건 / 에러: {len(error_df)}건\n")
+
+    # 정합성 메트릭 — 적재 보존(bronze 로드) + 전처리(정상/에러)
+    log_dq(
+        logger,
+        stage="bronze_to_silver",
+        bronze_loaded=len(raw_df),
+        silver_ok=len(silver_df),
+        silver_error=len(error_df),
+    )
 
     print("10. Iceberg write...")
     write_to_iceberg(silver_df, error_df)


### PR DESCRIPTION
## 변경
- **bronze_to_silver** (`src/bronze_to_silver/pipeline.py`): `log_dq(stage=bronze_to_silver, bronze_loaded, silver_ok, silver_error)` 추가 → 적재 보존 + 전처리 정합성 지표.
- **DAG** (`dags/oliveyoung_pipeline.py`): `silver_to_gold` 뒤 `gold_cdc`(gold_pipeline) 태스크 추가.
- **entrypoint.sh**: `gold_pipeline` 커맨드 매핑.

## 참고
- 정합성 수치는 Loki에 `[DQ]` JSON으로 적재 → Grafana LogQL로 패널화.
- 실데이터상 `bronze_loaded`와 `silver_ok+error`가 단순 합이 안 맞을 수 있어 (중복/에러 카운트 기준) → 항등식 가정 말고 3값을 관찰.