### PR TITLE
feat: bronze→silver 전처리 에러율 메트릭

### DIFF
--- a/src/bronze_to_silver/pipeline.py
+++ b/src/bronze_to_silver/pipeline.py
@@ -109,12 +109,16 @@ def run_pipeline():
     print(f"   정상: {len(silver_df)}건 / 에러: {len(error_df)}건\n")
 
     # 정합성 메트릭 — 적재 보존(bronze 로드) + 전처리(정상/에러)
+    # 에러율은 출력 안에서 닫힌 비율(dedup 영향 없음) — 점수판/임계값용
+    processed = len(silver_df) + len(error_df)
+    error_rate = round(len(error_df) / processed, 4) if processed else 0.0
     log_dq(
         logger,
         stage="bronze_to_silver",
         bronze_loaded=len(raw_df),
         silver_ok=len(silver_df),
         silver_error=len(error_df),
+        error_rate=error_rate,
     )
 
     print("10. Iceberg write...")


### PR DESCRIPTION
## 변경
`bronze_to_silver` log_dq에 `error_rate` 필드 추가.

- `error_rate = error / (ok + error)` — 출력 안에서 닫힌 비율이라 dedup 영향 없음
- 정합성 점수판(stat 패널)의 임계값 판단용 (초록 ≤0.05 / 노랑 ≤0.1 / 빨강)

## 영향
- 로직 변경 없음, 메트릭 1줄 추가
- 머지 후 다음 `bronze_to_silver` 실행부터 점수판 '전처리 에러율' 타일 활성화