### PR TITLE
feat(dq): dq_metrics 테이블 생성 배선 + bronze/gold writer 이중 기록

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -65,6 +65,7 @@ class OliveyoungIceberg:
     GOLD_PRODUCT_CHANGE_LOG_TABLE   = f"{DATABASE}.gold_product_change_log"
     GOLD_PRODUCT_INGREDIENTS_TABLE  = f"{DATABASE}.gold_product_ingredients"
     NEO4J_SYNC_CHECKPOINT_TABLE     = f"{DATABASE}.neo4j_sync_checkpoint"
+    DQ_METRICS_TABLE                = f"{DATABASE}.dq_metrics"   # 정합성 메트릭(생성·쓰기는 oliveyoung_common.dq_metrics)
     TYPO_MAP_TABLE                  = f"{DATABASE}.typo_map"
     GARBAGE_KEYWORDS_TABLE          = f"{DATABASE}.garbage_keywords"
     CUSTOM_INGREDIENT_DICT_TABLE    = f"{DATABASE}.custom_ingredient_dict"

--- a/gold_pipeline/create_gold_tables.py
+++ b/gold_pipeline/create_gold_tables.py
@@ -12,6 +12,7 @@ Gold 레이어 Iceberg 테이블 초기화 스크립트
 import logging
 
 from oliveyoung_common.logging import setup_logging
+from oliveyoung_common.dq_metrics import create_dq_metrics_table
 from config.settings import OliveyoungIceberg, S3
 from gold_pipeline.schemas import (
     GOLD_INGREDIENT_FREQUENCY_PARTITION,
@@ -79,13 +80,19 @@ def create_neo4j_sync_checkpoint(catalog) -> None:
     )
 
 
+def create_dq_metrics(catalog) -> None:
+    # 스키마·생성 로직은 oliveyoung_common이 소유, 여기선 위치만 지정해 호출
+    created = create_dq_metrics_table(catalog, location=f"{S3.GOLD_PATH}dq_metrics")
+    logger.info("dq_metrics 테이블 " + ("생성 완료" if created else "이미 존재함 (건너뜀)"))
+
+
 if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(description="Gold 테이블 초기화")
     parser.add_argument(
         "table",
-        choices=["ingredient_frequency", "product_change_log", "neo4j_sync_checkpoint", "all"],
+        choices=["ingredient_frequency", "product_change_log", "neo4j_sync_checkpoint", "dq_metrics", "all"],
         help="생성할 테이블 선택 (all: 전체 생성)",
     )
     args = parser.parse_args()
@@ -100,3 +107,6 @@ if __name__ == "__main__":
 
     if args.table in ("neo4j_sync_checkpoint", "all"):
         create_neo4j_sync_checkpoint(catalog)
+
+    if args.table in ("dq_metrics", "all"):
+        create_dq_metrics(catalog)

--- a/gold_pipeline/write_gold_product_ingredients.py
+++ b/gold_pipeline/write_gold_product_ingredients.py
@@ -22,6 +22,7 @@ from pyiceberg.expressions import AlwaysTrue
 from config.settings import OliveyoungIceberg, INCIIceberg
 from gold_pipeline.write_gold import _build_arrow
 from oliveyoung_common.logging import log_dq
+from oliveyoung_common.dq_metrics import write_dq_metrics
 
 logger = logging.getLogger(__name__)
 
@@ -89,16 +90,25 @@ def write_gold_product_ingredients(
     match_rate = matched / total if total else 0
     logger.info(f"unique 성분: {total}건 | INCI 매핑 성공: {matched}건 ({match_rate:.1%})")
 
-    # 정합성 메트릭 — Loki에서 LogQL로 추출 (매핑률 등)
-    log_dq(
-        logger,
-        stage="silver_to_gold",
-        batch_job=batch_job,
+    # 정합성 메트릭 — 로그(Loki) + 테이블(dq_metrics) 이중 기록, 같은 수치
+    metrics = dict(
         ingredients_unique=int(total),
         ingredients_matched=int(matched),
         ingredients_unmatched=int(total - matched),
         match_rate=round(float(match_rate), 4),
     )
+    log_dq(logger, stage="silver_to_gold", batch_job=batch_job, **metrics)
+    # 테이블 적재 실패가 파이프라인을 깨지 않도록 비치명적 처리
+    try:
+        write_dq_metrics(
+            catalog,
+            stage="silver_to_gold",
+            batch_job=batch_job,
+            target_table=OliveyoungIceberg.GOLD_PRODUCT_INGREDIENTS_TABLE,
+            **metrics,
+        )
+    except Exception as e:
+        logger.warning(f"dq_metrics 적재 실패(무시): {e}")
 
     result_df["batch_job"]  = batch_job
     result_df["batch_date"] = pd.to_datetime(batch_date, utc=True)

--- a/src/bronze_to_silver/pipeline.py
+++ b/src/bronze_to_silver/pipeline.py
@@ -19,6 +19,8 @@ from src.bronze_to_silver.ac_builder import (
 from src.bronze_to_silver.cleaner import process_pipeline
 from silver_pipeline.write_silver import write_to_iceberg, write_csv_to_s3
 from oliveyoung_common.logging import log_dq
+from oliveyoung_common.dq_metrics import write_dq_metrics
+from oliveyoung_common.batch import build_run_id
 
 logger = logging.getLogger(__name__)
 
@@ -112,14 +114,27 @@ def run_pipeline():
     # 에러율은 출력 안에서 닫힌 비율(dedup 영향 없음) — 점수판/임계값용
     processed = len(silver_df) + len(error_df)
     error_rate = round(len(error_df) / processed, 4) if processed else 0.0
-    log_dq(
-        logger,
-        stage="bronze_to_silver",
+    batch_job = build_run_id("bronze_to_silver")   # 이 run의 대조·드릴다운 키
+    metrics = dict(
         bronze_loaded=len(raw_df),
         silver_ok=len(silver_df),
         silver_error=len(error_df),
         error_rate=error_rate,
     )
+    # 로그(Loki) + 테이블(dq_metrics) 이중 기록, 같은 수치
+    log_dq(logger, stage="bronze_to_silver", batch_job=batch_job, **metrics)
+    # 테이블 적재 실패가 파이프라인을 깨지 않도록 비치명적 처리
+    # (참고: 현재 silver 행엔 batch_job이 안 찍혀 배치-정밀 드릴다운은 후속 과제)
+    try:
+        write_dq_metrics(
+            OliveyoungIceberg.get_catalog(),
+            stage="bronze_to_silver",
+            batch_job=batch_job,
+            target_table=OliveyoungIceberg.SILVER_CURRENT_TABLE,
+            **metrics,
+        )
+    except Exception as e:
+        logger.warning(f"dq_metrics 적재 실패(무시): {e}")
 
     print("10. Iceberg write...")
     write_to_iceberg(silver_df, error_df)


### PR DESCRIPTION
## 요약
- `gold_pipeline/create_gold_tables.py`에 `dq_metrics` 테이블 생성 옵션 추가 (스키마·생성 로직은 oliveyoung_common 소유, 위치만 지정)
- `config/settings.py`에 `DQ_METRICS_TABLE` 상수
- **bronze_to_silver / silver_to_gold**: 기존 log_dq(Loki)에 더해 **dq_metrics 테이블 적재(write_dq_metrics)** 이중 기록. 같은 수치, 적재 실패는 비치명적(파이프라인 안 깨짐)

## 의존
- oliveyoung_common의 `dq_metrics` 계약 필요 → 서브모듈 핀 d3b91cd로 bump 포함

## 배포 후 필요
- `python gold_pipeline/create_gold_tables.py dq_metrics` 로 테이블 1회 생성