### PR TITLE
fix(create_tables): PYTHONPATH 불필요 + neo4j 파티션 UNPARTITIONED

### DIFF
--- a/gold_pipeline/create_gold_tables.py
+++ b/gold_pipeline/create_gold_tables.py
@@ -10,6 +10,15 @@ Gold 레이어 Iceberg 테이블 초기화 스크립트
 """
 
 import logging
+import os
+import sys
+
+# gold_pipeline/에서 직접 실행해도 레포 루트를 import 경로에 추가 (PYTHONPATH 불필요)
+_PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from pyiceberg.partitioning import UNPARTITIONED_PARTITION_SPEC
 
 from oliveyoung_common.logging import setup_logging
 from oliveyoung_common.dq_metrics import create_dq_metrics_table
@@ -74,7 +83,7 @@ def create_neo4j_sync_checkpoint(catalog) -> None:
         catalog=catalog,
         identifier=OliveyoungIceberg.NEO4J_SYNC_CHECKPOINT_TABLE,
         schema=NEO4J_SYNC_CHECKPOINT_SCHEMA,
-        partition=None,
+        partition=UNPARTITIONED_PARTITION_SPEC,
         sort_order=NEO4J_SYNC_CHECKPOINT_SORT,
         location=f"{S3.GOLD_PATH}neo4j_sync_checkpoint",
     )


### PR DESCRIPTION
## 문제
- `python gold_pipeline/create_gold_tables.py`를 수동 실행하면 레포 루트가 sys.path에 없어 `ModuleNotFoundError: oliveyoung_common`
- neo4j 생성 시 `partition=None`이 pyiceberg에서 실패 (EC2에서 로컬로 발견·패치돼 있던 것)

## 수정
- 스크립트 상단에 **sys.path 부트스트랩** — gold_pipeline/에서 직접 실행해도 레포 루트를 import 경로에 추가 (PYTHONPATH 불필요, write_gold_product_ingredients.py와 동일 패턴)
- neo4j `partition=None` → **`UNPARTITIONED_PARTITION_SPEC`** (명시적 무파티션, pyiceberg 기본값)

## 참고
- dq_metrics 생성은 partition_spec을 넘기지 않아(기본 unpartitioned) 영향 없음