### PR TITLE
feat(silver): goods_no 컬럼 추가

### DIFF
--- a/silver_pipeline/schemas.py
+++ b/silver_pipeline/schemas.py
@@ -63,6 +63,7 @@ SILVER_SCHEMA = Schema(
     NestedField(14, "crawled_at",              TimestamptzType(), required=False),
     NestedField(15, "batch_job",               StringType(),      required=False),
     NestedField(16, "batch_date",              TimestamptzType(), required=False),
+    NestedField(17, "goods_no",                StringType(),      required=False),  # 올리브영 상품번호(raw 통과)
 )
 
 # DLQ 패턴: 에러 원인 추적에 필요한 컬럼만 유지

--- a/silver_pipeline/write_silver.py
+++ b/silver_pipeline/write_silver.py
@@ -105,7 +105,7 @@ def _add_missing_columns_as_none(df: pd.DataFrame, target_columns: list[str]) ->
 
 def _evolve_schema(table) -> None:
     """
-    테이블에 batch_job, batch_date 컬럼이 없으면 추가합니다.
+    테이블에 batch_job, batch_date, goods_no 컬럼이 없으면 추가합니다.
     이미 존재하면 아무것도 하지 않습니다.
     """
     existing = {f.name for f in table.schema().fields}
@@ -115,6 +115,8 @@ def _evolve_schema(table) -> None:
             update.add_column("batch_job", StringType())
         if "batch_date" not in existing:
             update.add_column("batch_date", TimestamptzType())
+        if "goods_no" not in existing:
+            update.add_column("goods_no", StringType())
 
     # 참고:
     # update_schema() commit 이후에는 호출 측에서 table을 reload 해서

--- a/src/bronze_to_silver/cleaner.py
+++ b/src/bronze_to_silver/cleaner.py
@@ -392,6 +392,7 @@ def _clean_rows(
         url              = str(row.get('url', ''))
         main_category    = str(row.get('main_category', ''))
         sub_category     = str(row.get('sub_category', ''))
+        goods_no         = str(row.get('goods_no', ''))
 
         crawled_at_raw = row.get('crawled_at', None)
         try:
@@ -526,6 +527,7 @@ def _clean_rows(
             'review_stats':            review_stats,
             'product_url':             url,
             'crawled_at':              crawled_at,
+            'goods_no':                goods_no,
         })
 
     return interim_list, error_records
@@ -625,6 +627,7 @@ def _match_ingredients(
                 'review_stats':            row['review_stats'],
                 'product_url':             url,
                 'crawled_at':              crawled_at,
+                'goods_no':                row['goods_no'],
             })
 
         if (residual_text


### PR DESCRIPTION
## 개요
raw 데이터로 들어오는 `goods_no`(올리브영 상품번호)를 silver 스키마에 추가하고 전처리에서 통과시킵니다. 별도 가공 없이 값만 실어 나릅니다.

## 변경 내용
- **silver_pipeline/schemas.py** — `SILVER_SCHEMA`에 `goods_no`(id 17, StringType, nullable) 추가 → silver_current/history 공유 스키마라 양쪽 반영
- **silver_pipeline/write_silver.py** — `_evolve_schema()`에 goods_no 추가. 이미 존재하는 current/history 테이블에도 컬럼 자동 부착(없을 때만)
- **src/bronze_to_silver/cleaner.py** — raw `goods_no` 읽어 interim → silver 레코드까지 통과

## 배포 메모
- 테이블 재생성 불필요. DAG(bronze→silver) 한 번 실행 시 `_evolve_schema`가 기존 테이블에 컬럼을 additive하게 추가하고 신규 배치부터 값 적재.
- 기존 history 행의 goods_no는 NULL(추가 이전 데이터).
- `SILVER_ERROR_SCHEMA`는 범위 밖이라 미변경.