### PR TITLE
feat(silver/neo4j): goods_no error 경로 + neo4j 전파 (PR #25 후속)

### DIFF
--- a/gold_pipeline/cdc.py
+++ b/gold_pipeline/cdc.py
@@ -33,6 +33,7 @@ _BASE_SELECTED_FIELDS = (
     "review_count",
     "review_stats",
     "batch_date",
+    "goods_no",
 )
 
 _CHANGE_TRACK_FIELDS = ("product_ingredients", "rating", "review_count", "review_stats")
@@ -245,6 +246,7 @@ def compute_change_log(catalog, batch: BatchMetadata) -> pd.DataFrame | None:
         "review_count",
         "review_stats",
         "batch_job",
+        "goods_no",
     ]
     for col in output_cols:
         if col not in change_df.columns:

--- a/gold_pipeline/schemas.py
+++ b/gold_pipeline/schemas.py
@@ -85,6 +85,7 @@ GOLD_PRODUCT_CHANGE_LOG_SCHEMA = Schema(
     NestedField(9,  "review_count",  IntegerType(),                required=False),
     NestedField(10, "review_stats",  _CHANGE_LOG_REVIEW_STATS_TYPE, required=False),
     NestedField(11, "batch_job",     StringType(),                 required=False),
+    NestedField(12, "goods_no",      StringType(),                 required=False),  # 올리브영 상품번호(raw 통과)
 )
 
 # batch_date 일 단위 파티션

--- a/gold_pipeline/write_gold.py
+++ b/gold_pipeline/write_gold.py
@@ -194,6 +194,14 @@ def write_gold_change_log(catalog, change_df: pd.DataFrame) -> None:
         return
 
     change_table = catalog.load_table(OliveyoungIceberg.GOLD_PRODUCT_CHANGE_LOG_TABLE)
+
+    # 기존 테이블에 goods_no 컬럼이 없으면 추가 (없으면 _build_arrow 단계에서 값이 버려짐)
+    if "goods_no" not in {field.name for field in change_table.schema().fields}:
+        with change_table.update_schema() as update:
+            update.add_column("goods_no", StringType())
+        change_table = catalog.load_table(OliveyoungIceberg.GOLD_PRODUCT_CHANGE_LOG_TABLE)
+        logger.info("schema evolve 완료: gold_product_change_log goods_no 추가")
+
     arrow_table  = _build_arrow(change_df, change_table)
     change_table.append(arrow_table)
 

--- a/gold_pipeline/write_neo4j_csv.py
+++ b/gold_pipeline/write_neo4j_csv.py
@@ -44,6 +44,7 @@ PRODUCT_COLUMNS: list[CsvColumn] = [
     CsvColumn(name="product_name"),
     CsvColumn(name="brand", source="product_brand"),
     CsvColumn(name="category"),
+    CsvColumn(name="goods_no"),  # 올리브영 상품번호(raw 통과)
 ]
 
 
@@ -57,7 +58,7 @@ def write_product_node_csv() -> None:
         table = catalog.load_table(OliveyoungIceberg.SILVER_CURRENT_TABLE)
         df: pd.DataFrame = (
             table.scan(
-                selected_fields=("product_id", "product_name", "product_brand", "category"),
+                selected_fields=("product_id", "product_name", "product_brand", "category", "goods_no"),
             ).to_pandas()
         )
 

--- a/models/pipeline_models.py
+++ b/models/pipeline_models.py
@@ -28,6 +28,7 @@ class ErrorRecord:
     crawled_at:              Any   # pd.Timestamp | pd.NaT
     error_type:              str
     residual_text:           str
+    goods_no:                str = ""   # 올리브영 상품번호(raw 통과)
 
     def to_dict(self) -> dict:
         return asdict(self)

--- a/neo4j_incremental.py
+++ b/neo4j_incremental.py
@@ -130,12 +130,14 @@ def apply_new(tx, product: dict, mapping: dict[str, str]) -> None:
         MERGE (p:Product {product_id: $product_id})
         SET p.product_name = $product_name,
             p.brand        = $brand,
-            p.category     = $category
+            p.category     = $category,
+            p.goods_no     = $goods_no
         """,
         product_id=product["product_id"],
         product_name=product.get("product_name"),
         brand=product.get("product_brand"),
         category=product.get("category_id"),
+        goods_no=product.get("goods_no"),
     )
     _merge_contains(tx, product["product_id"], product.get("product_ingredients") or [], mapping)
 
@@ -153,12 +155,14 @@ def apply_changed(tx, product: dict, mapping: dict[str, str]) -> None:
         MATCH (p:Product {product_id: $product_id})
         SET p.product_name = $product_name,
             p.brand        = $brand,
-            p.category     = $category
+            p.category     = $category,
+            p.goods_no     = $goods_no
         """,
         product_id=product["product_id"],
         product_name=product.get("product_name"),
         brand=product.get("product_brand"),
         category=product.get("category_id"),
+        goods_no=product.get("goods_no"),
     )
     tx.run(
         "MATCH (p:Product {product_id: $product_id})-[r:CONTAINS]->() DELETE r",

--- a/silver_pipeline/schemas.py
+++ b/silver_pipeline/schemas.py
@@ -82,6 +82,7 @@ SILVER_ERROR_SCHEMA = Schema(
     NestedField(12, "residual_text",           StringType(),      required=False),
     NestedField(13, "batch_job",               StringType(),      required=False),
     NestedField(14, "batch_date",              TimestamptzType(), required=False),
+    NestedField(15, "goods_no",                StringType(),      required=False),  # 올리브영 상품번호(raw 통과)
 )
 
 

--- a/src/bronze_to_silver/cleaner.py
+++ b/src/bronze_to_silver/cleaner.py
@@ -254,6 +254,7 @@ def _make_error(
     crawled_at,
     error_type:              str,
     residual_text:           str,
+    goods_no:                str = "",
 ) -> ErrorRecord:
     """에러 레코드를 생성합니다."""
     return ErrorRecord(
@@ -269,6 +270,7 @@ def _make_error(
         crawled_at              = crawled_at,
         error_type              = error_type,
         residual_text           = residual_text,
+        goods_no                = goods_no,
     )
 
 
@@ -430,6 +432,7 @@ def _clean_rows(
                 raw_text, url, crawled_at,
                 'INCOMPLETE_DATA_REJECTED',
                 f"Missing fields: {', '.join(missing_fields)}",
+                goods_no,
             ))
             continue
 
@@ -442,6 +445,7 @@ def _clean_rows(
                 raw_text, url, crawled_at,
                 'OPTION_BUNDLE_REJECTED',
                 'Multi-option product (n-종) detected in name',
+                goods_no,
             ))
             continue
 
@@ -454,6 +458,7 @@ def _clean_rows(
                 raw_text, url, crawled_at,
                 'INVALID_METADATA_REJECTED',
                 f"Garbage name detected: {product_name_raw!r}",
+                goods_no,
             ))
             continue
 
@@ -491,6 +496,7 @@ def _clean_rows(
                 brand, product_name_raw, clean_product_name,
                 raw_text, url, crawled_at,
                 'HETEROGENEOUS_BUNDLE_REJECTED', text,
+                goods_no,
             ))
             continue
 
@@ -501,6 +507,7 @@ def _clean_rows(
                 brand, product_name_raw, clean_product_name,
                 raw_text, url, crawled_at,
                 'HETEROGENEOUS_BUNDLE_REJECTED', text,
+                goods_no,
             ))
             continue
         elif bundle_count == 1:
@@ -552,6 +559,7 @@ def _dedup_interim(interim_list: list[dict]) -> tuple[pd.DataFrame, list[dict]]:
             r['product_ingredients_raw'], r['product_url'], r['crawled_at'],
             'DUPLICATE_PRODUCT_REJECTED',
             f"Duplicate of {r['product_brand']} | {r['product_name']}",
+            r['goods_no'],
         )
         for r in interim_df[duplicate_mask].to_dict('records')
     ]
@@ -601,6 +609,7 @@ def _match_ingredients(
                 row['product_brand'], row['product_name_raw'], row['product_name'],
                 row['product_ingredients_raw'], url, crawled_at,
                 'HIDDEN_BUNDLE_REJECTED', 'Duplicate Core Ingredients',
+                row['goods_no'],
             ))
             continue
 
@@ -638,6 +647,7 @@ def _match_ingredients(
                 row['product_brand'], row['product_name_raw'], row['product_name'],
                 row['product_ingredients_raw'], url, crawled_at,
                 'UNMAPPED_RESIDUAL', residual_text,
+                row['goods_no'],
             ))
 
     return silver_records, error_records


### PR DESCRIPTION
## 배경
PR #25가 첫 커밋(silver_current/history goods_no)만 담긴 채 머지되어, 나머지 goods_no 배선을 후속으로 올립니다.

## 변경 내용 (3 커밋)
1. **error 경로** — `SILVER_ERROR_SCHEMA` + `ErrorRecord` + `_make_error` 호출부 8곳에 goods_no
2. **neo4j 최초 적재 CSV** — Product 노드(`write_neo4j_csv.py`)에 goods_no 속성 + scan 필드
3. **neo4j 증분 경로** — CDC(`cdc.py`) → change_log 스키마(`gold_pipeline/schemas.py`) → change_log write evolve(`write_gold.py`) → 증분 Cypher(`neo4j_incremental.py`)

## 배포 메모
- 전부 additive 스키마 진화. 테이블 재생성 불필요.
- silver / gold_product_change_log 테이블은 다음 파이프라인 실행 시 goods_no 컬럼 자동 추가.
- 기존 누적 행은 NULL/빈값, 컬럼 추가 이후 배치부터 값 채워짐.