### PR TITLE
feat(dq): 전처리 파이프라인 batch_date 관통 배선

### DIFF
--- a/dags/oliveyoung_pipeline.py
+++ b/dags/oliveyoung_pipeline.py
@@ -18,6 +18,8 @@ COMMON = dict(
         "AWS_SECRET_ACCESS_KEY": os.environ.get("AWS_SECRET_ACCESS_KEY", ""),
         "LOG_FORMAT": "json",
         "LOG_LEVEL": "INFO",
+        # 크롤 DAG conf에서 전파된 논리 배치 날짜 → 전 스테이지 공유(없으면 각자 파생)
+        "BATCH_DATE": "{{ dag_run.conf.get('batch_date', '') }}",
     },
 )
 

--- a/gold_pipeline/write_gold_product_ingredients.py
+++ b/gold_pipeline/write_gold_product_ingredients.py
@@ -103,7 +103,8 @@ def write_gold_product_ingredients(
         write_dq_metrics(
             catalog,
             stage="silver_to_gold",
-            batch_job=batch_job,
+            batch_date=batch_date.strftime("%Y-%m-%d"),
+            run_id=batch_job,
             target_table=OliveyoungIceberg.GOLD_PRODUCT_INGREDIENTS_TABLE,
             **metrics,
         )

--- a/src/bronze_to_silver/cleaner.py
+++ b/src/bronze_to_silver/cleaner.py
@@ -665,6 +665,7 @@ def process_pipeline(
     garbage_config: dict = None,
     product_name_norm_list: list[dict] = None,
     batch: BatchMetadata = None,
+    batch_date: str = None,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     """
     Bronze raw DataFrame을 받아 silver / error DataFrame으로 전처리합니다.
@@ -697,7 +698,7 @@ def process_pipeline(
 
     if not interim_list:
         error_df = pd.DataFrame([r.to_dict() for r in error_records])
-        add_batch_metadata(error_df, batch)
+        add_batch_metadata(error_df, batch, batch_date)
         return pd.DataFrame(), error_df
 
     # [Step 10] 중복 제거
@@ -712,6 +713,6 @@ def process_pipeline(
     error_df  = pd.DataFrame([r.to_dict() for r in error_records])
 
     for df_ in (silver_df, error_df):
-        add_batch_metadata(df_, batch)
+        add_batch_metadata(df_, batch, batch_date)
 
     return silver_df, error_df

--- a/src/bronze_to_silver/pipeline.py
+++ b/src/bronze_to_silver/pipeline.py
@@ -3,6 +3,8 @@ Bronze → Silver 전처리 파이프라인 오케스트레이션 로직
 """
 
 import logging
+import os
+import re
 import sys
 
 from config.settings import OliveyoungIceberg, INCIIceberg, DuckDB
@@ -20,7 +22,7 @@ from src.bronze_to_silver.cleaner import process_pipeline
 from silver_pipeline.write_silver import write_to_iceberg, write_csv_to_s3
 from oliveyoung_common.logging import log_dq
 from oliveyoung_common.dq_metrics import write_dq_metrics
-from oliveyoung_common.batch import build_run_id
+from oliveyoung_common.batch import build_run_id, batch_date_from_run_id
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +32,7 @@ def load_bronze_data(con):
     DuckDB 커넥션으로 최신 run_id bronze 파일을 로드합니다.
 
     Returns:
-        pd.DataFrame: bronze raw 데이터
+        (raw_df, source_run_id): bronze raw 데이터 + 소스 run_id(max, 단독 실행 batch_date 파생용)
     """
     print("2. 최신 run_id bronze 파일 탐색...")
     try:
@@ -50,7 +52,11 @@ def load_bronze_data(con):
         sys.exit(1)
     print(f"   로드 완료: {len(raw_df)}건\n")
 
-    return raw_df
+    # 로드한 파일 경로에서 소스 run_id(max) 추출 — 단독 실행 시 batch_date 파생용
+    run_ids = [m.group(1) for f in latest_files if (m := re.search(r"run_id=([^/]+)/", f))]
+    source_run_id = max(run_ids) if run_ids else ""
+
+    return raw_df, source_run_id
 
 
 def load_dictionaries() -> Dictionaries:
@@ -96,8 +102,14 @@ def run_pipeline():
     print("1. DuckDB 커넥션 설정...")
     con = DuckDB.get_connection()
 
-    raw_df = load_bronze_data(con)
+    raw_df, source_run_id = load_bronze_data(con)
     dicts  = load_dictionaries()
+
+    # 단계 관통 논리 배치 날짜 — Airflow가 BATCH_DATE로 주입, 단독 실행 시 소스 bronze run_id에서 파생
+    batch_date = os.environ.get("BATCH_DATE") or (
+        batch_date_from_run_id(source_run_id) if source_run_id
+        else batch_date_from_run_id(build_run_id("bronze_to_silver"))
+    )
 
     print("9. 전처리 파이프라인 실행...")
     silver_df, error_df = process_pipeline(
@@ -107,6 +119,7 @@ def run_pipeline():
         typo_regex_list        = dicts.typo_regex_list,
         garbage_config         = dicts.garbage_config,
         product_name_norm_list = dicts.product_name_norm_list,
+        batch_date             = batch_date,
     )
     print(f"   정상: {len(silver_df)}건 / 에러: {len(error_df)}건\n")
 
@@ -114,7 +127,7 @@ def run_pipeline():
     # 에러율은 출력 안에서 닫힌 비율(dedup 영향 없음) — 점수판/임계값용
     processed = len(silver_df) + len(error_df)
     error_rate = round(len(error_df) / processed, 4) if processed else 0.0
-    batch_job = build_run_id("bronze_to_silver")   # 이 run의 대조·드릴다운 키
+    batch_job = build_run_id("bronze_to_silver")   # 이 run의 유니크 식별(run_id 컬럼용)
     metrics = dict(
         bronze_loaded=len(raw_df),
         silver_ok=len(silver_df),
@@ -124,12 +137,13 @@ def run_pipeline():
     # 로그(Loki) + 테이블(dq_metrics) 이중 기록, 같은 수치
     log_dq(logger, stage="bronze_to_silver", batch_job=batch_job, **metrics)
     # 테이블 적재 실패가 파이프라인을 깨지 않도록 비치명적 처리
-    # (참고: 현재 silver 행엔 batch_job이 안 찍혀 배치-정밀 드릴다운은 후속 과제)
+    # silver 행·dq_metrics 모두 같은 batch_date로 찍혀 배치-정밀 드릴다운 가능
     try:
         write_dq_metrics(
             OliveyoungIceberg.get_catalog(),
             stage="bronze_to_silver",
-            batch_job=batch_job,
+            batch_date=batch_date,
+            run_id=batch_job,
             target_table=OliveyoungIceberg.SILVER_CURRENT_TABLE,
             **metrics,
         )

--- a/src/silver_to_gold/pipeline.py
+++ b/src/silver_to_gold/pipeline.py
@@ -3,12 +3,15 @@ Silver → Gold 파이프라인 오케스트레이션 로직
 """
 
 import logging
+import os
+from datetime import datetime, timezone
 
 from config.settings import OliveyoungIceberg
 from gold_pipeline.cdc import compute_change_log
 from gold_pipeline.write_gold import write_gold_change_log, write_gold_ingredient_frequency
 from gold_pipeline.write_gold_product_ingredients import write_gold_product_ingredients
 from models.batch_metadata import BatchMetadata, create_batch_metadata
+from oliveyoung_common.batch import batch_date_from_run_id
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +19,10 @@ logger = logging.getLogger(__name__)
 def run_pipeline():
     """Silver → Gold 파이프라인 전체를 실행합니다."""
     batch_base = create_batch_metadata("iceberg_silver_to_gold")
-    batch = BatchMetadata(batch_job=batch_base.run_id, batch_date=batch_base.batch_date)
+    # 단계 관통 논리 배치 날짜 — Airflow가 BATCH_DATE로 주입, 단독 실행 시 run_id에서 파생
+    batch_date_str = os.environ.get("BATCH_DATE") or batch_date_from_run_id(batch_base.run_id)
+    batch_date_dt = datetime.strptime(batch_date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    batch = BatchMetadata(batch_job=batch_base.run_id, batch_date=batch_date_dt)
 
     logger.info(f"=== Silver → Gold 파이프라인 시작: batch_job={batch.batch_job} ===")
 


### PR DESCRIPTION
bronze_to_silver / silver_to_gold가 논리 배치 날짜를 dq_metrics·silver에 일관 기록.

- DAG: conf.batch_date → BATCH_DATE env 전 스테이지 전파
- bronze_to_silver: 소스 run_id/env로 batch_date 계산 → silver stamp + write_dq_metrics
- cleaner: process_pipeline batch_date 전달
- silver_to_gold: 논리 batch_date로 batch 구성 → gold/CDC 공유 + write_dq_metrics

⚠️ oliveyoung_common v2 서브모듈 bump 선행 필수(ImportError 방지).