### PR TITLE
feat(dq): bronze/gold 완료 리포트 배선

### DIFF
--- a/dags/oliveyoung_pipeline.py
+++ b/dags/oliveyoung_pipeline.py
@@ -20,6 +20,8 @@ COMMON = dict(
         "LOG_LEVEL": "INFO",
         # 크롤 DAG conf에서 전파된 논리 배치 날짜 → 전 스테이지 공유(없으면 각자 파생)
         "BATCH_DATE": "{{ dag_run.conf.get('batch_date', '') }}",
+        # bronze/silver 완료 리포트용 웹훅(없으면 미전송)
+        "DISCORD_DQ_WEBHOOK_URL": os.environ.get("DISCORD_DQ_WEBHOOK_URL", ""),
     },
 )
 

--- a/gold_pipeline/write_gold_product_ingredients.py
+++ b/gold_pipeline/write_gold_product_ingredients.py
@@ -106,6 +106,7 @@ def write_gold_product_ingredients(
             batch_date=batch_date.strftime("%Y-%m-%d"),
             run_id=batch_job,
             target_table=OliveyoungIceberg.GOLD_PRODUCT_INGREDIENTS_TABLE,
+            report_webhook=os.environ.get("DISCORD_DQ_WEBHOOK_URL"),  # 완료 리포트(옵트인)
             **metrics,
         )
     except Exception as e:

--- a/src/bronze_to_silver/pipeline.py
+++ b/src/bronze_to_silver/pipeline.py
@@ -145,6 +145,7 @@ def run_pipeline():
             batch_date=batch_date,
             run_id=batch_job,
             target_table=OliveyoungIceberg.SILVER_CURRENT_TABLE,
+            report_webhook=os.environ.get("DISCORD_DQ_WEBHOOK_URL"),  # 완료 리포트(옵트인)
             **metrics,
         )
     except Exception as e:


### PR DESCRIPTION
## 요약
bronze_to_silver·silver_to_gold 단계 완료 시 dq_metrics 리포트를 Discord(#파이프라인-리포트)로 전송.

- 두 `write_dq_metrics` 호출에 `report_webhook=os.environ.get("DISCORD_DQ_WEBHOOK_URL")` 추가
- `dags/oliveyoung_pipeline.py`: COMMON `environment`에 `DISCORD_DQ_WEBHOOK_URL` 추가(bronze/gold 컨테이너로 전달)

## 의존
oliveyoung_common#6 머지 + 서브모듈 자동 bump(→ d6db1ea) 완료 후라 안전.

## 배포 메모
- 런타임 파이프라인 코드는 ECR 이미지(force_pull)로 반영.
- EC2 Airflow_Infra/.env 에 DISCORD_DQ_WEBHOOK_URL 필요.